### PR TITLE
The most significant change is the modification of the `AdditionalInc…

### DIFF
--- a/ArkShop/ArkShop/ArkShop.vcxproj
+++ b/ArkShop/ArkShop/ArkShop.vcxproj
@@ -66,7 +66,7 @@
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;SHOP_EXPORTS;_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS;_CRT_SECURE_NO_WARNINGS;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(SolutionDir)Arkshop\Public;$(SolutionDir)..\Permissions\Permissions\Public;$(SolutionDir)Includes;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\ARK;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\UE;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\Logger;$(SolutionDir)..\..\ServerAPI\AsaApi\vcpkg_installed\x64-windows\x64-windows\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Arkshop\Public;$(SolutionDir)..\Permissions\Permissions\Public;$(SolutionDir)Includes;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\ARK;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\UE;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\Logger;$(SolutionDir)..\..\ServerAPI\AsaApi\vcpkg_installed\x64-windows-static-md\x64-windows-static-md\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -92,7 +92,7 @@
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;SHOP_EXPORTS;_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS;_CRT_SECURE_NO_WARNINGS;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(SolutionDir)Arkshop\Public;$(SolutionDir)..\Permissions\Permissions\Public;$(SolutionDir)Includes;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\ARK;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\UE;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\Logger;$(SolutionDir)..\..\ServerAPI\AsaApi\vcpkg_installed\x64-windows\x64-windows\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Arkshop\Public;$(SolutionDir)..\Permissions\Permissions\Public;$(SolutionDir)Includes;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\ARK;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\UE;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\Logger;$(SolutionDir)..\..\ServerAPI\AsaApi\vcpkg_installed\x64-windows-static-md\x64-windows-static-md\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Permissions/Permissions/Permissions.vcxproj
+++ b/Permissions/Permissions/Permissions.vcxproj
@@ -94,7 +94,7 @@
       <PreprocessorDefinitions>NDEBUG;PERMISSIONS_EXPORTS;_WINDOWS;_USRDLL;ARK_EXPORTS;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;PERMISSIONS_ARK;_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(SolutionDir)Includes;$(SolutionDir)Includes\sqlite3;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\ARK;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\UE;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\Logger;$(SolutionDir)..\..\ServerAPI\AsaApi\vcpkg_installed\x64-windows\x64-windows\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Includes;$(SolutionDir)Includes\sqlite3;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\ARK;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\UE;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\Logger;$(SolutionDir)..\..\ServerAPI\AsaApi\vcpkg_installed\x64-windows-static-md\x64-windows-static-md\include</AdditionalIncludeDirectories>
       <LanguageStandard_C>Default</LanguageStandard_C>
     </ClCompile>
     <Link>
@@ -120,7 +120,7 @@
       <PreprocessorDefinitions>NDEBUG;PERMISSIONS_EXPORTS;_WINDOWS;_USRDLL;ARK_EXPORTS;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;PERMISSIONS_ARK;_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(SolutionDir)Includes;$(SolutionDir)Includes\sqlite3;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\ARK;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\UE;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\Logger;$(SolutionDir)..\..\ServerAPI\AsaApi\vcpkg_installed\x64-windows\x64-windows\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Includes;$(SolutionDir)Includes\sqlite3;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\ARK;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\UE;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\Logger;$(SolutionDir)..\..\ServerAPI\AsaApi\vcpkg_installed\x64-windows-static-md\x64-windows-static-md\include</AdditionalIncludeDirectories>
       <LanguageStandard_C>Default</LanguageStandard_C>
     </ClCompile>
     <Link>


### PR DESCRIPTION
…ludeDirectories` tag in the `ArkShop.vcxproj` and `Permissions.vcxproj` files. The directory path has been updated to point to a new location.

Changes:
1. In the `ArkShop.vcxproj` and `Permissions.vcxproj` files, the `AdditionalIncludeDirectories` tag has been modified. The previous directory path `$(SolutionDir)..\..\ServerAPI\AsaApi\vcpkg_installed\x64-windows\x64-windows\include` has been replaced with a new one `$(SolutionDir)..\..\ServerAPI\AsaApi\vcpkg_installed\x64-windows-static-md\x64-windows-static-md\include`. This change indicates that the project's include directories are now pointing to a different location.