### PR TITLE
Permissions: Improve Permissions.dll exports

### DIFF
--- a/Permissions/Permissions/Permissions.vcxproj
+++ b/Permissions/Permissions/Permissions.vcxproj
@@ -94,7 +94,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;PERMISSIONS_EXPORTS;_WINDOWS;_USRDLL;ARK_EXPORTS;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;PERMISSIONS_ARK;_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;PERMISSIONS_EXPORTS;_WINDOWS;_USRDLL;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;PERMISSIONS_ARK;_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>$(SolutionDir)Includes;$(SolutionDir)Includes\sqlite3;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\ARK;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\UE;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\Logger;$(SolutionDir)..\..\ServerAPI\AsaApi\vcpkg_installed\x64-windows-static-md\x64-windows-static-md\include</AdditionalIncludeDirectories>
@@ -120,7 +120,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;PERMISSIONS_EXPORTS;_WINDOWS;_USRDLL;ARK_EXPORTS;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;PERMISSIONS_ARK;_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;PERMISSIONS_EXPORTS;_WINDOWS;_USRDLL;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;PERMISSIONS_ARK;_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>$(SolutionDir)Includes;$(SolutionDir)Includes\sqlite3;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\ARK;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\API\UE;$(SolutionDir)..\..\ServerAPI\AsaApi\Core\Public\Logger;$(SolutionDir)..\..\ServerAPI\AsaApi\vcpkg_installed\x64-windows-static-md\x64-windows-static-md\include</AdditionalIncludeDirectories>

--- a/Permissions/Permissions/Public/DBHelper.h
+++ b/Permissions/Permissions/Public/DBHelper.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#ifdef ARK_EXPORTS
-#define ARK_API __declspec(dllexport)
+#ifdef PERMISSIONS_EXPORTS
+#define PERMISSIONS_API __declspec(dllexport)
 #else
-#define ARK_API __declspec(dllimport)
+#define PERMISSIONS_API __declspec(dllimport)
 #endif
 
 class FString;
@@ -13,10 +13,10 @@ namespace Permissions::DB
 	/**
 	 * \brief Checks if player exists in database
 	 */
-	ARK_API bool IsPlayerExists(const FString& eos_id);
+	PERMISSIONS_API bool IsPlayerExists(const FString& eos_id);
 
 	/**
 	* \brief Checks if group exists in database
 	*/
-	ARK_API bool IsGroupExists(const FString& group);
+	PERMISSIONS_API bool IsGroupExists(const FString& group);
 }

--- a/Permissions/Permissions/Public/Permissions.h
+++ b/Permissions/Permissions/Public/Permissions.h
@@ -42,6 +42,6 @@ namespace Permissions
 	PERMISSIONS_API bool IsTribeHasPermission(int tribeId, const FString& permission);
 	PERMISSIONS_API TArray<FString> GetTribeGroups(int tribeId);
 
-	PERMISSIONS_API void AddPlayerPermissionCallback(FString CallbackName, bool onlyCheckOnline, bool cacheBySteamId, bool cacheByTribe, const std::function<TArray<FString>(FString*, int*)>& callback);
+	PERMISSIONS_API void AddPlayerPermissionCallback(FString CallbackName, bool onlyCheckOnline, bool cacheBySteamId, bool cacheByTribe, const std::function<TArray<FString>(const FString&, int*)>& callback);
 	PERMISSIONS_API void RemovePlayerPermissionCallback(FString CallbackName);
 }

--- a/Permissions/Permissions/Public/Permissions.h
+++ b/Permissions/Permissions/Public/Permissions.h
@@ -2,46 +2,46 @@
 
 #include <API/Ark/Ark.h>
 
-#ifdef ARK_EXPORTS
-#define ARK_API __declspec(dllexport)
+#ifdef PERMISSIONS_EXPORTS
+#define PERMISSIONS_API __declspec(dllexport)
 #else
-#define ARK_API __declspec(dllimport)
+#define PERMISSIONS_API __declspec(dllimport)
 #endif
 
 namespace Permissions
 {
-	ARK_API TArray<FString> GetPlayerGroups(const FString& eos_id);
-	ARK_API TArray<FString> GetGroupPermissions(const FString& group);
-	ARK_API TArray<FString> GetGroupMembers(const FString& group);
+	PERMISSIONS_API TArray<FString> GetPlayerGroups(const FString& eos_id);
+	PERMISSIONS_API TArray<FString> GetGroupPermissions(const FString& group);
+	PERMISSIONS_API TArray<FString> GetGroupMembers(const FString& group);
 
-	ARK_API bool IsPlayerInGroup(const FString& eos_id, const FString& group);
+	PERMISSIONS_API bool IsPlayerInGroup(const FString& eos_id, const FString& group);
 
-	ARK_API std::optional<std::string> AddPlayerToGroup(const FString& eos_id, const FString& group);
-	ARK_API std::optional<std::string> RemovePlayerFromGroup(const FString& eos_id, const FString& group);
+	PERMISSIONS_API std::optional<std::string> AddPlayerToGroup(const FString& eos_id, const FString& group);
+	PERMISSIONS_API std::optional<std::string> RemovePlayerFromGroup(const FString& eos_id, const FString& group);
 
-	ARK_API std::optional<std::string> AddPlayerToTimedGroup(const FString& eos_id, const FString& group, int secs, int delaySecs);
-	ARK_API std::optional<std::string> RemovePlayerFromTimedGroup(const FString& eos_id, const FString& group);
+	PERMISSIONS_API std::optional<std::string> AddPlayerToTimedGroup(const FString& eos_id, const FString& group, int secs, int delaySecs);
+	PERMISSIONS_API std::optional<std::string> RemovePlayerFromTimedGroup(const FString& eos_id, const FString& group);
 
-	ARK_API std::optional<std::string> AddGroup(const FString& group);
-	ARK_API std::optional<std::string> RemoveGroup(const FString& group);
+	PERMISSIONS_API std::optional<std::string> AddGroup(const FString& group);
+	PERMISSIONS_API std::optional<std::string> RemoveGroup(const FString& group);
 
-	ARK_API bool IsGroupHasPermission(const FString& group, const FString& permission);
-	ARK_API bool IsPlayerHasPermission(const FString& eos_id, const FString& permission);
+	PERMISSIONS_API bool IsGroupHasPermission(const FString& group, const FString& permission);
+	PERMISSIONS_API bool IsPlayerHasPermission(const FString& eos_id, const FString& permission);
 
-	ARK_API std::optional<std::string> GroupGrantPermission(const FString& group, const FString& permission);
-	ARK_API std::optional<std::string> GroupRevokePermission(const FString& group, const FString& permission);
+	PERMISSIONS_API std::optional<std::string> GroupGrantPermission(const FString& group, const FString& permission);
+	PERMISSIONS_API std::optional<std::string> GroupRevokePermission(const FString& group, const FString& permission);
 
 
-	ARK_API std::optional<std::string> AddTribeToGroup(int tribeId, const FString& group);
-	ARK_API std::optional<std::string> RemoveTribeFromGroup(int tribeId, const FString& group);
+	PERMISSIONS_API std::optional<std::string> AddTribeToGroup(int tribeId, const FString& group);
+	PERMISSIONS_API std::optional<std::string> RemoveTribeFromGroup(int tribeId, const FString& group);
 
-	ARK_API std::optional<std::string> AddTribeToTimedGroup(int tribeId, const FString& group, int secs, int delaySecs);
-	ARK_API std::optional<std::string> RemoveTribeFromTimedGroup(int tribeId, const FString& group);
+	PERMISSIONS_API std::optional<std::string> AddTribeToTimedGroup(int tribeId, const FString& group, int secs, int delaySecs);
+	PERMISSIONS_API std::optional<std::string> RemoveTribeFromTimedGroup(int tribeId, const FString& group);
 
-	ARK_API bool IsTribeInGroup(int tribeId, const FString& group);
-	ARK_API bool IsTribeHasPermission(int tribeId, const FString& permission);
-	ARK_API TArray<FString> GetTribeGroups(int tribeId);
+	PERMISSIONS_API bool IsTribeInGroup(int tribeId, const FString& group);
+	PERMISSIONS_API bool IsTribeHasPermission(int tribeId, const FString& permission);
+	PERMISSIONS_API TArray<FString> GetTribeGroups(int tribeId);
 
-	ARK_API void AddPlayerPermissionCallback(FString CallbackName, bool onlyCheckOnline, bool cacheBySteamId, bool cacheByTribe, const std::function<TArray<FString>(FString*, int*)>& callback);
-	ARK_API void RemovePlayerPermissionCallback(FString CallbackName);
+	PERMISSIONS_API void AddPlayerPermissionCallback(FString CallbackName, bool onlyCheckOnline, bool cacheBySteamId, bool cacheByTribe, const std::function<TArray<FString>(FString*, int*)>& callback);
+	PERMISSIONS_API void RemovePlayerPermissionCallback(FString CallbackName);
 }


### PR DESCRIPTION
**Remove AsaApi function exports**
Permissions uses the `ARK_EXPORTS` and `ARK_API` defines in the same way as the AsaApi headers. This results in Permissions.dll exporting functions from the included AsaApi headers. This change replaces `ARK_EXPORTS` and `ARK_API` in the Permissions code with `PERMISSIONS_EXPORTS` and `PERMISSIONS_API` so that Permissions.dll only exports Permissions functions.

**Export AddPlayerPermissionCallback()**
`AddPlayerPermissionCallback()` is declared as an API function in Permissions.h. However, the declaration does not match the function definition, resulting in the function not being exported by the DLL. This change fixes the declaration to match the definition.

Before:
```
  Section contains the following exports for Permissions.dll

    00000000 characteristics
    FFFFFFFF time date stamp
        0.00 version
           1 ordinal base
          79 number of functions
          79 number of names
```
After:
```
  Section contains the following exports for Permissions.dll

    00000000 characteristics
    FFFFFFFF time date stamp
        0.00 version
           1 ordinal base
          25 number of functions
          25 number of names
```